### PR TITLE
refactor: use `jsdoc/recommended-typescript-flavor`

### DIFF
--- a/base-configs/jsdoc.js
+++ b/base-configs/jsdoc.js
@@ -6,7 +6,7 @@ const config = {
     'jsdoc',
   ],
   'extends': [
-    'plugin:jsdoc/recommended',
+    'plugin:jsdoc/recommended-typescript-flavor',
   ],
   settings: {
     jsdoc: {
@@ -15,7 +15,6 @@ const config = {
   },
   rules: {
     'jsdoc/check-types': 'off',
-    'jsdoc/no-undefined-types': 'off',
     'jsdoc/require-jsdoc': 'off',
     'jsdoc/require-param-description': 'off',
     'jsdoc/require-property-description': 'off',


### PR DESCRIPTION
The `jsdoc/recommended-typescript-flavor` is geared towards the same use case as this config is, enables me to remove at least one customized property