### PR TITLE
feat!: add `eslint-plugin-regexp` recommended

### DIFF
--- a/base-configs/regexp.js
+++ b/base-configs/regexp.js
@@ -1,0 +1,6 @@
+import { configs } from 'eslint-plugin-regexp';
+
+/** @satisfies {import('eslint').Linter.Config[]} */
+export const regexpRules = [
+  configs['flat/recommended'],
+];

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ import { esmRules } from './base-configs/esm.js';
 import { jsdocRules } from './base-configs/jsdoc.js';
 import { mochaRules } from './base-configs/mocha.js';
 import { nodeRules } from './base-configs/node.js';
+import { regexpRules } from './base-configs/regexp.js';
 import { modifiedNeostandardRules } from './base-configs/modified-rules.js';
 
 /**
@@ -36,6 +37,7 @@ export function voxpelli (options) {
     ...modifiedNeostandardRules,
     ...additionalRules,
     ...jsdocRules,
+    ...regexpRules,
     ...nodeRules(cjs),
     ...cjs ? [] : esmRules,
     ...noMocha ? [] : mochaRules,

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "eslint-plugin-es-x": "^8.0.0",
         "eslint-plugin-jsdoc": "^50.0.0",
         "eslint-plugin-mocha": "^10.5.0",
+        "eslint-plugin-regexp": "^2.6.0",
         "eslint-plugin-security": "^3.0.1",
         "eslint-plugin-sort-destructure-keys": "^2.0.0",
         "eslint-plugin-unicorn": "^55.0.0",
@@ -3086,6 +3087,27 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-regexp": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-regexp/-/eslint-plugin-regexp-2.6.0.tgz",
+      "integrity": "sha512-FCL851+kislsTEQEMioAlpDuK5+E5vs0hi1bF8cFlPlHcEjeRhuAzEsGikXRreE+0j4WhW2uO54MqTjXtYOi3A==",
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.9.1",
+        "comment-parser": "^1.4.0",
+        "jsdoc-type-pratt-parser": "^4.0.0",
+        "refa": "^0.12.1",
+        "regexp-ast-analysis": "^0.7.1",
+        "scslre": "^0.3.0"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.44.0"
       }
     },
     "node_modules/eslint-plugin-security": {
@@ -6680,6 +6702,18 @@
         "node": ">=10.13"
       }
     },
+    "node_modules/refa": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/refa/-/refa-0.12.1.tgz",
+      "integrity": "sha512-J8rn6v4DBb2nnFqkqwy6/NnTYMcgLA+sLr0iIO41qpv0n+ngb7ksag2tMRl0inb1bbO/esUwzW1vbJi7K0sI0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.8.0"
+      },
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.6.tgz",
@@ -6699,6 +6733,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexp-ast-analysis": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/regexp-ast-analysis/-/regexp-ast-analysis-0.7.1.tgz",
+      "integrity": "sha512-sZuz1dYW/ZsfG17WSAG7eS85r5a0dDsvg+7BiiYR5o6lKCAtUrEwdmRmaGF6rwVj3LcmAeYkOWKEPlbPzN3Y3A==",
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.8.0",
+        "refa": "^0.12.1"
+      },
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
     "node_modules/regexp-tree": {
@@ -6955,6 +7002,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/scslre": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/scslre/-/scslre-0.3.0.tgz",
+      "integrity": "sha512-3A6sD0WYP7+QrjbfNA2FN3FsOaGGFoekCVgTyypy53gPxhbkCIjtO6YWgdrfM+n/8sI8JeXZOIxsHjMTNxQ4nQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.8.0",
+        "refa": "^0.12.0",
+        "regexp-ast-analysis": "^0.7.0"
+      },
+      "engines": {
+        "node": "^14.0.0 || >=16.0.0"
       }
     },
     "node_modules/semver": {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "eslint-plugin-es-x": "^8.0.0",
     "eslint-plugin-jsdoc": "^50.0.0",
     "eslint-plugin-mocha": "^10.5.0",
+    "eslint-plugin-regexp": "^2.6.0",
     "eslint-plugin-security": "^3.0.1",
     "eslint-plugin-sort-destructure-keys": "^2.0.0",
     "eslint-plugin-unicorn": "^55.0.0",


### PR DESCRIPTION
Companion to https://github.com/voxpelli/eslint-config/pull/371 which disables the `unicorn/better-regexp` rule. This PR restores it using the recommended module.

See https://github.com/sindresorhus/eslint-plugin-unicorn/issues/2409 and https://github.com/typescript-eslint/typescript-eslint/pull/9948 for context.