### PR TITLE
ci: external-canary workflow improvements

### DIFF
--- a/.github/workflows/external.yml
+++ b/.github/workflows/external.yml
@@ -28,8 +28,17 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@v6
+      - id: validate-module-set
+        env:
+          INPUT: ${{ github.event.inputs.moduleSet }}
+        run: |
+          case "$INPUT" in
+            compliant|preFlatconfigCompliant|nonCompliant|"") ;;
+            *) echo "::error::Invalid moduleSet: $INPUT"; exit 1 ;;
+          esac
+          echo "value=${INPUT:-compliant}" >> "$GITHUB_OUTPUT"
       - id: set-matrix
-        run: echo "matrix=$(cat workflow-external.json | jq -c '.${{ github.event.inputs.moduleSet || 'compliant' }}')" >> $GITHUB_OUTPUT
+        run: echo "matrix=$(cat workflow-external.json | jq -c ".${{ steps.validate-module-set.outputs.value }}")" >> "$GITHUB_OUTPUT"
 
   test_external:
     needs: read_external_projects
@@ -104,6 +113,7 @@ jobs:
           node -e "
             const fs = require('fs');
             const project = process.env.PROJECT;
+            const projectPrefix = process.cwd() + '/project/';
             let totals = { errorCount: 0, warningCount: 0, fixableErrorCount: 0, fixableWarningCount: 0 };
             const rules = {};
             try {
@@ -115,12 +125,16 @@ jobs:
                 totals.fixableWarningCount += file.fixableWarningCount;
                 for (const msg of file.messages) {
                   if (!msg.ruleId) continue;
-                  const key = msg.ruleId;
+                  const isValidRuleId = typeof msg.ruleId === 'string' && /^[@a-z0-9/_-]+$/i.test(msg.ruleId);
+                  const key = isValidRuleId ? msg.ruleId : '(invalid rule id)';
                   if (!rules[key]) rules[key] = { errors: 0, warnings: 0, fixable: 0, files: [] };
                   if (msg.severity === 2) rules[key].errors++;
                   else rules[key].warnings++;
                   if (msg.fix) rules[key].fixable++;
-                  rules[key].files.push(file.filePath.replace(process.cwd() + '/project/', '') + ':' + msg.line);
+                  const cleanPath = typeof file.filePath === 'string' && file.filePath.startsWith(projectPrefix)
+                    ? file.filePath.slice(projectPrefix.length)
+                    : '<unexpected path>';
+                  rules[key].files.push(cleanPath + ':' + msg.line);
                 }
               }
             } catch {}
@@ -157,25 +171,39 @@ jobs:
             const fs = require('fs');
             const path = require('path');
 
+            const BIDI_ZW_CTRL = /[\u200B-\u200F\u202A-\u202E\u2060-\u2069\uFEFF]/g;
+            const stripCtrl = (s) => String(s).replace(BIDI_ZW_CTRL, '');
+            const escapeHtml = (s) => stripCtrl(s)
+              .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+              .replace(/\"/g, '&quot;').replace(/'/g, '&#39;');
+            const FILE_CAP = 50;
+            const SIZE_CAP = 60000;
+
             const dir = 'results';
             const results = [];
             if (fs.existsSync(dir)) {
               for (const sub of fs.readdirSync(dir)) {
                 const file = path.join(dir, sub, 'eslint-result.json');
-                if (fs.existsSync(file)) results.push(JSON.parse(fs.readFileSync(file, 'utf8')));
+                if (!fs.existsSync(file)) continue;
+                if (fs.statSync(file).size > 5 * 1024 * 1024) continue;
+                let parsed;
+                try { parsed = JSON.parse(fs.readFileSync(file, 'utf8')); } catch { continue; }
+                if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) continue;
+                if (parsed.rules && (typeof parsed.rules !== 'object' || Array.isArray(parsed.rules))) continue;
+                results.push(parsed);
               }
             }
-            results.sort((a, b) => a.project.localeCompare(b.project));
+            results.sort((a, b) => String(a.project).localeCompare(String(b.project)));
 
             if (results.length === 0) {
               fs.writeFileSync('comment.md', '');
               process.exit(0);
             }
 
-            const totalErrors = results.reduce((s, r) => s + r.errorCount, 0);
-            const totalWarnings = results.reduce((s, r) => s + r.warningCount, 0);
-            const totalFixableE = results.reduce((s, r) => s + r.fixableErrorCount, 0);
-            const totalFixableW = results.reduce((s, r) => s + r.fixableWarningCount, 0);
+            const totalErrors = results.reduce((s, r) => s + (r.errorCount|0), 0);
+            const totalWarnings = results.reduce((s, r) => s + (r.warningCount|0), 0);
+            const totalFixableE = results.reduce((s, r) => s + (r.fixableErrorCount|0), 0);
+            const totalFixableW = results.reduce((s, r) => s + (r.fixableWarningCount|0), 0);
 
             let md = '## External project test results\n\n';
             md += '**' + results.length + ' project(s) failed**';
@@ -184,10 +212,13 @@ jobs:
             md += '\n\n';
 
             for (const r of results) {
-              const link = '[' + r.project + '](https://github.com/' + r.project + ')';
-              const fixable = r.fixableErrorCount + r.fixableWarningCount;
+              const isValidSlug = typeof r.project === 'string' && /^[\w.-]+\/[\w.-]+$/.test(r.project);
+              const label = isValidSlug
+                ? '[' + escapeHtml(r.project) + '](https://github.com/' + r.project + ')'
+                : escapeHtml(r.project);
+              const fixable = (r.fixableErrorCount|0) + (r.fixableWarningCount|0);
               const fixStr = fixable > 0 ? ' (' + fixable + ' fixable :wrench:)' : '';
-              md += '<details>\n<summary>' + link + ' &mdash; ' + r.errorCount + ' errors, ' + r.warningCount + ' warnings' + fixStr + '</summary>\n\n';
+              md += '<details>\n<summary>' + label + ' &mdash; ' + (r.errorCount|0) + ' errors, ' + (r.warningCount|0) + ' warnings' + fixStr + '</summary>\n\n';
               md += '| Errors | Warnings | Fixable | Rule |\n';
               md += '|-------:|---------:|--------:|------|\n';
 
@@ -196,12 +227,21 @@ jobs:
                 .sort((a, b) => b.errors - a.errors || b.warnings - a.warnings || a.id.localeCompare(b.id));
 
               for (const rule of ruleEntries) {
-                const fileList = '<ul><li>' + rule.files.join('</li><li>') + '</li></ul>';
+                const shownFiles = (rule.files || []).slice(0, FILE_CAP);
+                const overflow = (rule.files || []).length - shownFiles.length;
+                const fileBlock = '<pre><code>' +
+                  shownFiles.map(escapeHtml).join('\n') +
+                  (overflow > 0 ? '\n... and ' + overflow + ' more' : '') +
+                  '</code></pre>';
                 const fixCol = rule.fixable > 0 ? rule.fixable + ' :wrench:' : '-';
-                md += '| ' + rule.errors + ' | ' + rule.warnings + ' | ' + fixCol + ' | <details><summary>' + rule.id + '</summary>' + fileList + '</details> |\n';
+                md += '| ' + rule.errors + ' | ' + rule.warnings + ' | ' + fixCol + ' | <details><summary><code>' + escapeHtml(rule.id) + '</code></summary>' + fileBlock + '</details> |\n';
               }
 
               md += '\n</details>\n\n';
+            }
+
+            if (Buffer.byteLength(md, 'utf8') > SIZE_CAP) {
+              md = md.slice(0, SIZE_CAP - 5000) + '\n\n_(comment truncated — too many failures to render)_\n';
             }
 
             fs.writeFileSync('comment.md', md);

--- a/.github/workflows/external.yml
+++ b/.github/workflows/external.yml
@@ -18,13 +18,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-
 jobs:
   read_external_projects:
     name: Read list of ${{ github.event.inputs.moduleSet || 'compliant' }} external projects
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -36,6 +35,8 @@ jobs:
     needs: read_external_projects
     name: Test ${{ matrix.project }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -93,5 +94,138 @@ jobs:
         working-directory: ./project
 
       - name: run eslint
-        run: ../main/node_modules/.bin/eslint
+        id: eslint
+        run: ../main/node_modules/.bin/eslint --format json --output-file eslint-results.json
         working-directory: ./project
+
+      - name: prepare result
+        if: ${{ failure() && steps.eslint.outcome == 'failure' }}
+        run: |
+          node -e "
+            const fs = require('fs');
+            const project = process.env.PROJECT;
+            let totals = { errorCount: 0, warningCount: 0, fixableErrorCount: 0, fixableWarningCount: 0 };
+            const rules = {};
+            try {
+              const data = JSON.parse(fs.readFileSync('project/eslint-results.json', 'utf8'));
+              for (const file of data) {
+                totals.errorCount += file.errorCount;
+                totals.warningCount += file.warningCount;
+                totals.fixableErrorCount += file.fixableErrorCount;
+                totals.fixableWarningCount += file.fixableWarningCount;
+                for (const msg of file.messages) {
+                  if (!msg.ruleId) continue;
+                  const key = msg.ruleId;
+                  if (!rules[key]) rules[key] = { errors: 0, warnings: 0, fixable: 0, files: [] };
+                  if (msg.severity === 2) rules[key].errors++;
+                  else rules[key].warnings++;
+                  if (msg.fix) rules[key].fixable++;
+                  rules[key].files.push(file.filePath.replace(process.cwd() + '/project/', '') + ':' + msg.line);
+                }
+              }
+            } catch {}
+            fs.writeFileSync('eslint-result.json', JSON.stringify({ project, ...totals, rules }));
+          "
+        env:
+          PROJECT: ${{ matrix.project }}
+
+      - name: upload result
+        if: ${{ failure() && steps.eslint.outcome == 'failure' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: eslint-result-${{ strategy.job-index }}-${{ github.run_attempt }}
+          path: eslint-result.json
+          retention-days: 1
+
+  summary:
+    name: Post test summary
+    needs: [test_external]
+    if: ${{ !cancelled() && github.event.pull_request.number }}
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: download all results
+        uses: actions/download-artifact@v4
+        with:
+          pattern: eslint-result-*-${{ github.run_attempt }}
+          path: results
+
+      - name: generate comment
+        run: |
+          node -e "
+            const fs = require('fs');
+            const path = require('path');
+
+            const dir = 'results';
+            const results = [];
+            if (fs.existsSync(dir)) {
+              for (const sub of fs.readdirSync(dir)) {
+                const file = path.join(dir, sub, 'eslint-result.json');
+                if (fs.existsSync(file)) results.push(JSON.parse(fs.readFileSync(file, 'utf8')));
+              }
+            }
+            results.sort((a, b) => a.project.localeCompare(b.project));
+
+            if (results.length === 0) {
+              fs.writeFileSync('comment.md', '');
+              process.exit(0);
+            }
+
+            const totalErrors = results.reduce((s, r) => s + r.errorCount, 0);
+            const totalWarnings = results.reduce((s, r) => s + r.warningCount, 0);
+            const totalFixableE = results.reduce((s, r) => s + r.fixableErrorCount, 0);
+            const totalFixableW = results.reduce((s, r) => s + r.fixableWarningCount, 0);
+
+            let md = '## External project test results\n\n';
+            md += '**' + results.length + ' project(s) failed**';
+            if (totalErrors > 0) md += ' &mdash; ' + totalErrors + ' errors (' + totalFixableE + ' fixable)';
+            if (totalWarnings > 0) md += ', ' + totalWarnings + ' warnings (' + totalFixableW + ' fixable)';
+            md += '\n\n';
+
+            for (const r of results) {
+              const link = '[' + r.project + '](https://github.com/' + r.project + ')';
+              const fixable = r.fixableErrorCount + r.fixableWarningCount;
+              const fixStr = fixable > 0 ? ' (' + fixable + ' fixable :wrench:)' : '';
+              md += '<details>\n<summary>' + link + ' &mdash; ' + r.errorCount + ' errors, ' + r.warningCount + ' warnings' + fixStr + '</summary>\n\n';
+              md += '| Errors | Warnings | Fixable | Rule |\n';
+              md += '|-------:|---------:|--------:|------|\n';
+
+              const ruleEntries = Object.entries(r.rules || {})
+                .map(([id, d]) => ({ id, ...d }))
+                .sort((a, b) => b.errors - a.errors || b.warnings - a.warnings || a.id.localeCompare(b.id));
+
+              for (const rule of ruleEntries) {
+                const fileList = '<ul><li>' + rule.files.join('</li><li>') + '</li></ul>';
+                const fixCol = rule.fixable > 0 ? rule.fixable + ' :wrench:' : '-';
+                md += '| ' + rule.errors + ' | ' + rule.warnings + ' | ' + fixCol + ' | <details><summary>' + rule.id + '</summary>' + fileList + '</details> |\n';
+              }
+
+              md += '\n</details>\n\n';
+            }
+
+            fs.writeFileSync('comment.md', md);
+          "
+
+      - name: check for results
+        id: check
+        run: |
+          if [ -s comment.md ]; then
+            echo "has_results=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_results=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: post comment
+        if: steps.check.outputs.has_results == 'true'
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0
+        with:
+          header: external-test-results
+          path: comment.md
+
+      - name: delete stale comment
+        if: steps.check.outputs.has_results != 'true'
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0
+        with:
+          header: external-test-results
+          delete: true

--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   test:
@@ -20,3 +21,6 @@ jobs:
   external:
     needs: [test]
     uses: ./.github/workflows/external.yml
+    permissions:
+      contents: read
+      pull-requests: write

--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -12,7 +12,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   test:

--- a/.github/workflows/sync-external-dependents.yml
+++ b/.github/workflows/sync-external-dependents.yml
@@ -1,0 +1,20 @@
+name: Sync External Dependents
+
+on:
+  schedule:
+    - cron: '0 6 * * 1' # weekly, Monday 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    uses: voxpelli/ghatemplates/.github/workflows/sync-reusable.yml@main
+    secrets: inherit
+    with:
+      npm-sync-script: dependents
+      diff-files: dependents-data/filtered.json
+      branch-name: chore/sync-external-dependents
+      commit-message: 'chore: sync external dependents data'


### PR DESCRIPTION
## Summary

Extracts three workflow-only changes from the pending \`evaluation\` major-release branch so they can land on \`main\` ahead of v25:

- **feat: sticky PR comment with external test results** (\`4f17ee1\`, cherry-picked from \`2331ee5\`) — captures ESLint JSON output from each matrix job, aggregates via artifacts, and posts a collapsible summary table as a sticky PR comment using \`marocchino/sticky-pull-request-comment\`.
- **fix(ci): harden external.yml PR comment and scope permissions** (\`946e6b9\`, cherry-picked from \`fdf4497\`) — addresses Copilot and deeper security review findings on #454: validates rule IDs against a charset, HTML-escapes third-party repo output, strips bidi/zero-width chars, caps per-rule file lists and comment size, validates \`moduleSet\` input, caps artifact ingestion at 5MB, and drops workflow-level \`pull-requests: write\` from \`npm-test.yml\` so the reusable test job can't inherit it.
- **chore(ci): add weekly canary sync workflow** (\`1f177e4\`) — new \`sync-external-dependents.yml\` using \`ghatemplates/sync-reusable.yml\`. Extracted from \`3948e27\` (which also added \`eslint-plugin-perfectionist\`, shipping on \`evaluation\`).

These CI improvements don't need to wait for the major release. \`evaluation\` is left untouched — post-merge rebase will drop the two pure cherry-picked commits by patch-id.

## Test plan

- [ ] Dry-run: verify \`external.yml\` parses and the matrix job still produces JSON artifacts
- [ ] Verify sticky PR comment renders correctly on the first PR that runs this workflow
- [ ] Verify hardening: rule IDs with non-charset chars fall back safely; paths outside project prefix render as \`<unexpected path>\`
- [ ] Verify weekly canary sync workflow runs against \`ghatemplates/sync-reusable.yml\` on its schedule
- [ ] Confirm \`npm-test.yml\` no longer grants \`pull-requests: write\` at workflow level