### PR TITLE
ci: restore external-test failure visibility on non-PR events

### DIFF
--- a/.github/workflows/external.yml
+++ b/.github/workflows/external.yml
@@ -26,6 +26,7 @@ jobs:
       contents: read
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
+      count:  ${{ steps.set-matrix.outputs.count }}
     steps:
       - uses: actions/checkout@v6
       - id: validate-module-set
@@ -38,7 +39,10 @@ jobs:
           esac
           echo "value=${INPUT:-compliant}" >> "$GITHUB_OUTPUT"
       - id: set-matrix
-        run: echo "matrix=$(cat workflow-external.json | jq -c ".${{ steps.validate-module-set.outputs.value }}")" >> "$GITHUB_OUTPUT"
+        run: |
+          SET="${{ steps.validate-module-set.outputs.value }}"
+          echo "matrix=$(cat workflow-external.json | jq -c ".${SET}")" >> "$GITHUB_OUTPUT"
+          echo "count=$(cat workflow-external.json | jq ".${SET} | length")" >> "$GITHUB_OUTPUT"
 
   test_external:
     needs: read_external_projects
@@ -115,38 +119,7 @@ jobs:
 
       - name: prepare result
         if: ${{ !cancelled() && steps.eslint.conclusion != 'skipped' }}
-        run: |
-          node -e "
-            const fs = require('fs');
-            const project = process.env.PROJECT;
-            const projectPrefix = process.cwd() + '/project/';
-            let totals = { errorCount: 0, warningCount: 0, fixableErrorCount: 0, fixableWarningCount: 0 };
-            const rules = {};
-            try {
-              const data = JSON.parse(fs.readFileSync('project/eslint-results.json', 'utf8'));
-              for (const file of data) {
-                totals.errorCount += file.errorCount;
-                totals.warningCount += file.warningCount;
-                totals.fixableErrorCount += file.fixableErrorCount;
-                totals.fixableWarningCount += file.fixableWarningCount;
-                for (const msg of file.messages) {
-                  if (!msg.ruleId) continue;
-                  const isValidRuleId = typeof msg.ruleId === 'string' && /^[@a-z0-9/_-]+$/i.test(msg.ruleId);
-                  const key = isValidRuleId ? msg.ruleId : '(invalid rule id)';
-                  if (!rules[key]) rules[key] = { errors: 0, warnings: 0, fixable: 0, files: [] };
-                  if (msg.severity === 2) rules[key].errors++;
-                  else rules[key].warnings++;
-                  if (msg.fix) rules[key].fixable++;
-                  const cleanPath = typeof file.filePath === 'string' && file.filePath.startsWith(projectPrefix)
-                    ? file.filePath.slice(projectPrefix.length)
-                    : '<unexpected path>';
-                  rules[key].files.push(cleanPath + ':' + msg.line);
-                }
-              }
-            } catch {}
-            if (totals.errorCount === 0 && totals.warningCount === 0) process.exit(0);
-            fs.writeFileSync('eslint-result.json', JSON.stringify({ project, ...totals, rules }));
-          "
+        run: node main/tools/prepare-eslint-result.js
         env:
           PROJECT: ${{ matrix.project }}
 
@@ -159,123 +132,66 @@ jobs:
           retention-days: 1
 
   summary:
-    name: Post test summary
-    needs: [test_external]
+    name: Generate test summary
+    needs: [test_external, read_external_projects]
     if: ${{ !cancelled() && needs.test_external.result != 'skipped' }}
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: write
+      contents: read
+    outputs:
+      has_results: ${{ steps.check.outputs.has_results }}
     steps:
+      - uses: actions/checkout@v6
+        with:
+          path: main
       - name: download all results
         uses: actions/download-artifact@v4
         with:
           pattern: eslint-result-*-${{ github.run_attempt }}
           path: results
-
       - name: generate comment
-        run: |
-          node -e "
-            const fs = require('fs');
-            const path = require('path');
-
-            const BIDI_ZW_CTRL = /[\u200B-\u200F\u202A-\u202E\u2060-\u2069\uFEFF]/g;
-            const stripCtrl = (s) => String(s).replace(BIDI_ZW_CTRL, '');
-            const escapeHtml = (s) => stripCtrl(s)
-              .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
-              .replace(/\"/g, '&quot;').replace(/'/g, '&#39;');
-            const FILE_CAP = 50;
-            const SIZE_CAP = 60000;
-
-            const dir = 'results';
-            const results = [];
-            if (fs.existsSync(dir)) {
-              for (const sub of fs.readdirSync(dir)) {
-                const file = path.join(dir, sub, 'eslint-result.json');
-                if (!fs.existsSync(file)) continue;
-                if (fs.statSync(file).size > 5 * 1024 * 1024) continue;
-                let parsed;
-                try { parsed = JSON.parse(fs.readFileSync(file, 'utf8')); } catch { continue; }
-                if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) continue;
-                if (parsed.rules && (typeof parsed.rules !== 'object' || Array.isArray(parsed.rules))) continue;
-                results.push(parsed);
-              }
-            }
-            results.sort((a, b) => String(a.project).localeCompare(String(b.project)));
-
-            if (results.length === 0) {
-              fs.writeFileSync('comment.md', '');
-              process.exit(0);
-            }
-
-            const totalErrors = results.reduce((s, r) => s + (r.errorCount|0), 0);
-            const totalWarnings = results.reduce((s, r) => s + (r.warningCount|0), 0);
-            const totalFixableE = results.reduce((s, r) => s + (r.fixableErrorCount|0), 0);
-            const totalFixableW = results.reduce((s, r) => s + (r.fixableWarningCount|0), 0);
-
-            let md = '## External project test results\n\n';
-            md += '**' + results.length + ' project(s) reported issues**';
-            if (totalErrors > 0) md += ' &mdash; ' + totalErrors + ' errors (' + totalFixableE + ' fixable)';
-            if (totalWarnings > 0) md += ', ' + totalWarnings + ' warnings (' + totalFixableW + ' fixable)';
-            md += '\n\n';
-
-            for (const r of results) {
-              const isValidSlug = typeof r.project === 'string' && /^[\w.-]+\/[\w.-]+$/.test(r.project);
-              const label = isValidSlug
-                ? '[' + escapeHtml(r.project) + '](https://github.com/' + r.project + ')'
-                : escapeHtml(r.project);
-              const fixable = (r.fixableErrorCount|0) + (r.fixableWarningCount|0);
-              const fixStr = fixable > 0 ? ' (' + fixable + ' fixable :wrench:)' : '';
-              md += '<details>\n<summary>' + label + ' &mdash; ' + (r.errorCount|0) + ' errors, ' + (r.warningCount|0) + ' warnings' + fixStr + '</summary>\n\n';
-              md += '| Errors | Warnings | Fixable | Rule |\n';
-              md += '|-------:|---------:|--------:|------|\n';
-
-              const ruleEntries = Object.entries(r.rules || {})
-                .map(([id, d]) => ({ id, ...d }))
-                .sort((a, b) => b.errors - a.errors || b.warnings - a.warnings || a.id.localeCompare(b.id));
-
-              for (const rule of ruleEntries) {
-                const shownFiles = (rule.files || []).slice(0, FILE_CAP);
-                const overflow = (rule.files || []).length - shownFiles.length;
-                const fileBlock =
-                  shownFiles.map(f => '<code>' + escapeHtml(f) + '</code>').join('<br>') +
-                  (overflow > 0 ? '<br><em>... and ' + overflow + ' more</em>' : '');
-                const fixCol = rule.fixable > 0 ? rule.fixable + ' :wrench:' : '-';
-                md += '| ' + rule.errors + ' | ' + rule.warnings + ' | ' + fixCol + ' | <details><summary><code>' + escapeHtml(rule.id) + '</code></summary>' + fileBlock + '</details> |\n';
-              }
-
-              md += '\n</details>\n\n';
-            }
-
-            if (Buffer.byteLength(md, 'utf8') > SIZE_CAP) {
-              md = md.slice(0, SIZE_CAP - 5000) + '\n\n_(comment truncated — too many failures to render)_\n';
-            }
-
-            fs.writeFileSync('comment.md', md);
-          "
-
+        run: node main/tools/generate-canary-comment.js
+        env:
+          EXTERNAL_PROJECT_COUNT: ${{ needs.read_external_projects.outputs.count }}
       - name: check for results
         id: check
         run: |
           if [ -s comment.md ]; then
-            echo "has_results=true" >> $GITHUB_OUTPUT
+            echo "has_results=true"  >> $GITHUB_OUTPUT
           else
             echo "has_results=false" >> $GITHUB_OUTPUT
           fi
-
       - name: write step summary
-        if: steps.check.outputs.has_results == 'true'
         run: cat comment.md >> $GITHUB_STEP_SUMMARY
+      - name: upload comment
+        uses: actions/upload-artifact@v4
+        with:
+          name: canary-comment-${{ github.run_attempt }}
+          path: comment.md
+          retention-days: 1
 
-      - name: post comment
-        if: ${{ steps.check.outputs.has_results == 'true' && github.event.pull_request.number }}
+  post_comment:
+    name: Post sticky PR comment
+    needs: [summary]
+    if: ${{ !cancelled() && github.event.pull_request.number && needs.summary.result == 'success' }}
+    runs-on: ubuntu-latest
+    environment: pr-bot
+    permissions:
+      contents: read
+    steps:
+      - name: mint app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: '1082006'
+          private-key: ${{ secrets.APP_PEM }}
+      - name: download comment
+        uses: actions/download-artifact@v4
+        with:
+          name: canary-comment-${{ github.run_attempt }}
+      - name: post sticky comment
         uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0
         with:
           header: external-test-results
           path: comment.md
-
-      - name: delete stale comment
-        if: ${{ steps.check.outputs.has_results != 'true' && github.event.pull_request.number }}
-        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0
-        with:
-          header: external-test-results
-          delete: true
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/external.yml
+++ b/.github/workflows/external.yml
@@ -107,6 +107,12 @@ jobs:
         run: ../main/node_modules/.bin/eslint --format json --output-file eslint-results.json
         working-directory: ./project
 
+      - name: show errors in log
+        if: ${{ failure() && steps.eslint.outcome == 'failure' }}
+        run: ../main/node_modules/.bin/eslint --format stylish
+        working-directory: ./project
+        continue-on-error: true
+
       - name: prepare result
         if: ${{ failure() && steps.eslint.outcome == 'failure' }}
         run: |
@@ -154,7 +160,7 @@ jobs:
   summary:
     name: Post test summary
     needs: [test_external]
-    if: ${{ !cancelled() && github.event.pull_request.number }}
+    if: ${{ !cancelled() && needs.test_external.result != 'skipped' }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -256,15 +262,19 @@ jobs:
             echo "has_results=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: post comment
+      - name: write step summary
         if: steps.check.outputs.has_results == 'true'
+        run: cat comment.md >> $GITHUB_STEP_SUMMARY
+
+      - name: post comment
+        if: ${{ steps.check.outputs.has_results == 'true' && github.event.pull_request.number }}
         uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0
         with:
           header: external-test-results
           path: comment.md
 
       - name: delete stale comment
-        if: steps.check.outputs.has_results != 'true'
+        if: ${{ steps.check.outputs.has_results != 'true' && github.event.pull_request.number }}
         uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0
         with:
           header: external-test-results

--- a/.github/workflows/external.yml
+++ b/.github/workflows/external.yml
@@ -107,14 +107,14 @@ jobs:
         run: ../main/node_modules/.bin/eslint --format json --output-file eslint-results.json
         working-directory: ./project
 
-      - name: show errors in log
-        if: ${{ failure() && steps.eslint.outcome == 'failure' }}
+      - name: show lint output in log
+        if: ${{ !cancelled() && steps.eslint.conclusion != 'skipped' }}
         run: ../main/node_modules/.bin/eslint --format stylish
         working-directory: ./project
         continue-on-error: true
 
       - name: prepare result
-        if: ${{ failure() && steps.eslint.outcome == 'failure' }}
+        if: ${{ !cancelled() && steps.eslint.conclusion != 'skipped' }}
         run: |
           node -e "
             const fs = require('fs');
@@ -144,13 +144,14 @@ jobs:
                 }
               }
             } catch {}
+            if (totals.errorCount === 0 && totals.warningCount === 0) process.exit(0);
             fs.writeFileSync('eslint-result.json', JSON.stringify({ project, ...totals, rules }));
           "
         env:
           PROJECT: ${{ matrix.project }}
 
       - name: upload result
-        if: ${{ failure() && steps.eslint.outcome == 'failure' }}
+        if: ${{ !cancelled() && hashFiles('eslint-result.json') != '' }}
         uses: actions/upload-artifact@v4
         with:
           name: eslint-result-${{ strategy.job-index }}-${{ github.run_attempt }}
@@ -212,7 +213,7 @@ jobs:
             const totalFixableW = results.reduce((s, r) => s + (r.fixableWarningCount|0), 0);
 
             let md = '## External project test results\n\n';
-            md += '**' + results.length + ' project(s) failed**';
+            md += '**' + results.length + ' project(s) reported issues**';
             if (totalErrors > 0) md += ' &mdash; ' + totalErrors + ' errors (' + totalFixableE + ' fixable)';
             if (totalWarnings > 0) md += ', ' + totalWarnings + ' warnings (' + totalFixableW + ' fixable)';
             md += '\n\n';
@@ -235,10 +236,9 @@ jobs:
               for (const rule of ruleEntries) {
                 const shownFiles = (rule.files || []).slice(0, FILE_CAP);
                 const overflow = (rule.files || []).length - shownFiles.length;
-                const fileBlock = '<pre><code>' +
-                  shownFiles.map(escapeHtml).join('\n') +
-                  (overflow > 0 ? '\n... and ' + overflow + ' more' : '') +
-                  '</code></pre>';
+                const fileBlock =
+                  shownFiles.map(f => '<code>' + escapeHtml(f) + '</code>').join('<br>') +
+                  (overflow > 0 ? '<br><em>... and ' + overflow + ' more</em>' : '');
                 const fixCol = rule.fixable > 0 ? rule.fixable + ' :wrench:' : '-';
                 md += '| ' + rule.errors + ' | ' + rule.warnings + ' | ' + fixCol + ' | <details><summary><code>' + escapeHtml(rule.id) + '</code></summary>' + fileBlock + '</details> |\n';
               }

--- a/.github/workflows/external.yml
+++ b/.github/workflows/external.yml
@@ -173,18 +173,15 @@ jobs:
   post_comment:
     name: Post sticky PR comment
     needs: [summary]
-    if: ${{ !cancelled() && github.event.pull_request.number && needs.summary.result == 'success' }}
+    # Skip on fork PRs: GITHUB_TOKEN is read-only regardless of requested
+    # permissions, so the sticky-comment post would 403. Reviewers still
+    # get the step summary via the Actions run link.
+    if: ${{ !cancelled() && github.event.pull_request.number && github.event.pull_request.head.repo.full_name == github.repository && needs.summary.result == 'success' }}
     runs-on: ubuntu-latest
-    environment: pr-bot
     permissions:
       contents: read
+      pull-requests: write
     steps:
-      - name: mint app token
-        id: app-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: '1082006'
-          private-key: ${{ secrets.APP_PEM }}
       - name: download comment
         uses: actions/download-artifact@v4
         with:
@@ -194,4 +191,3 @@ jobs:
         with:
           header: external-test-results
           path: comment.md
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/tools/generate-canary-comment.js
+++ b/tools/generate-canary-comment.js
@@ -1,0 +1,120 @@
+// @ts-check
+
+// Assemble the external-canary sticky comment markdown from per-project
+// result artifacts. Reads results/*/eslint-result.json; writes comment.md.
+// On clean runs (no result files), emits a positive confirmation that
+// includes the total project count from env EXTERNAL_PROJECT_COUNT.
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+/** @typedef {{ errors: number, warnings: number, fixable: number, files: string[] }} RuleBucket */
+
+const BIDI_ZW_CTRL = /[\u200B-\u200F\u202A-\u202E\u2060-\u2069\uFEFF]/g;
+/** @param {unknown} s */
+const stripCtrl = (s) => String(s).replace(BIDI_ZW_CTRL, '');
+/** @param {unknown} s */
+const escapeHtml = (s) => stripCtrl(s)
+  .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+  .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+
+const FILE_CAP = 50;
+const SIZE_CAP = 60_000;
+
+const externalCount = Number(process.env['EXTERNAL_PROJECT_COUNT'] ?? 0);
+
+const dir = 'results';
+/** @type {Array<Record<string, unknown>>} */
+const results = [];
+if (fs.existsSync(dir)) {
+  for (const sub of fs.readdirSync(dir)) {
+    const file = path.join(dir, sub, 'eslint-result.json');
+    if (!fs.existsSync(file)) continue;
+    if (fs.statSync(file).size > 5 * 1024 * 1024) continue;
+    /** @type {unknown} */
+    let parsed;
+    try { parsed = JSON.parse(fs.readFileSync(file, 'utf8')); } catch { continue; }
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) continue;
+    const p = /** @type {Record<string, unknown>} */ (parsed);
+    if (p['rules'] && (typeof p['rules'] !== 'object' || Array.isArray(p['rules']))) continue;
+    results.push(p);
+  }
+}
+results.sort((a, b) => String(a['project']).localeCompare(String(b['project'])));
+
+if (results.length === 0) {
+  const n = externalCount > 0 ? String(externalCount) : '?';
+  fs.writeFileSync('comment.md',
+    `## External project test results\n\n:white_check_mark: All ${n} external projects pass\n`);
+  process.exit(0);
+}
+
+const hasSyntheticFootnote = results.some(r => {
+  const sk = r['syntheticKeys'];
+  return Array.isArray(sk) && sk.some(k => k === '(parser error)' || k === '(no rule id)');
+});
+
+const totalErrors    = results.reduce((s, r) => s + ((Number(r['errorCount'])          | 0)), 0);
+const totalWarnings  = results.reduce((s, r) => s + ((Number(r['warningCount'])        | 0)), 0);
+const totalFixableE  = results.reduce((s, r) => s + ((Number(r['fixableErrorCount'])   | 0)), 0);
+const totalFixableW  = results.reduce((s, r) => s + ((Number(r['fixableWarningCount']) | 0)), 0);
+
+let md = '## External project test results\n\n';
+md += '**' + results.length + ' project(s) reported issues**';
+if (totalErrors > 0)   md += ' &mdash; ' + totalErrors + ' errors (' + totalFixableE + ' fixable)';
+if (totalWarnings > 0) md += ', ' + totalWarnings + ' warnings (' + totalFixableW + ' fixable)';
+md += '\n\n';
+
+if (hasSyntheticFootnote) {
+  md += '<sub><em><code>(parser error)</code> — ESLint reported a fatal parse/syntax error without a rule id.<br>';
+  md += '<code>(no rule id)</code> — ESLint reported a non-fatal issue without attributing it to a named rule.</em></sub>\n\n';
+}
+
+for (const r of results) {
+  const slug = String(r['project']);
+  const isValidSlug = /^[\w.-]+\/[\w.-]+$/.test(slug);
+  const label = isValidSlug
+    ? '<a href="https://github.com/' + slug + '"><code>' + escapeHtml(slug) + '</code></a>'
+    : escapeHtml(slug);
+
+  const errorCount   = Number(r['errorCount'])   | 0;
+  const warningCount = Number(r['warningCount']) | 0;
+  const fixable      = (Number(r['fixableErrorCount']) | 0) + (Number(r['fixableWarningCount']) | 0);
+  const fixStr = fixable > 0 ? ' (' + fixable + ' fixable :wrench:)' : '';
+
+  md += '<details>\n<summary>' + label + ' &mdash; ' + errorCount + ' errors, ' + warningCount + ' warnings' + fixStr + '</summary>\n\n';
+  md += '| Errors | Warnings | Fixable | Rule |\n';
+  md += '|-------:|---------:|--------:|------|\n';
+
+  const rulesObj = r['rules'] && typeof r['rules'] === 'object' && !Array.isArray(r['rules'])
+    ? /** @type {Record<string, RuleBucket>} */ (r['rules'])
+    : {};
+
+  const ruleEntries = Object.entries(rulesObj)
+    .map(([id, d]) => ({ id, ...d }))
+    .sort((a, b) => b.errors - a.errors || b.warnings - a.warnings || a.id.localeCompare(b.id));
+
+  for (const rule of ruleEntries) {
+    const shownFiles = (rule.files || []).slice(0, FILE_CAP);
+    const overflow = (rule.files || []).length - shownFiles.length;
+
+    const fileSpans = shownFiles.map(f => {
+      const m = /^(.+):(\d+)$/.exec(f);
+      if (m && isValidSlug) {
+        const [, filePath, line] = m;
+        return '<a href="https://github.com/' + slug + '/blob/HEAD/' + encodeURI(filePath ?? '') + '#L' + line + '"><code>' + escapeHtml(f) + '</code></a>';
+      }
+      return '<code>' + escapeHtml(f) + '</code>';
+    });
+
+    const fileBlock = fileSpans.join('<br>') + (overflow > 0 ? '<br><em>... and ' + overflow + ' more</em>' : '');
+    const fixCol = rule.fixable > 0 ? rule.fixable + ' :wrench:' : '-';
+    md += '| ' + rule.errors + ' | ' + rule.warnings + ' | ' + fixCol + ' | <details><summary><code>' + escapeHtml(rule.id) + '</code></summary>' + fileBlock + '</details> |\n';
+  }
+  md += '\n</details>\n\n';
+}
+
+if (Buffer.byteLength(md, 'utf8') > SIZE_CAP) {
+  md = md.slice(0, SIZE_CAP - 5000) + '\n\n_(comment truncated — too many failures to render)_\n';
+}
+fs.writeFileSync('comment.md', md);

--- a/tools/generate-canary-comment.js
+++ b/tools/generate-canary-comment.js
@@ -87,10 +87,10 @@ md += '\n\n';
 if (hasSyntheticFootnote) {
   /** @type {Record<string, string>} */
   const FOOTNOTE_TEXT = {
-    '(parser error)':  'ESLint reported a fatal parse/syntax error without a rule id.',
-    '(no rule id)':    'ESLint reported a non-fatal issue without attributing it to a named rule.',
+    '(parser error)': 'ESLint reported a fatal parse/syntax error without a rule id.',
+    '(no rule id)': 'ESLint reported a non-fatal issue without attributing it to a named rule.',
     '(unused disable)': 'An <code>eslint-disable</code> directive reported no matching problems — the named rule is shown next to each file.',
-    '(missing rule)':  'An <code>eslint-disable</code> / config references a rule ESLint could not load (plugin uninstalled or rule removed) — the name is shown next to each file.',
+    '(missing rule)': 'An <code>eslint-disable</code> / config references a rule ESLint could not load (plugin uninstalled or rule removed) — the name is shown next to each file.',
   };
   const lines = [...presentSyntheticKeys].sort().map(k => '<code>' + escapeHtml(k) + '</code> — ' + FOOTNOTE_TEXT[String(k)]);
   md += '<sub><em>' + lines.join('<br>') + '</em></sub>\n\n';

--- a/tools/generate-canary-comment.js
+++ b/tools/generate-canary-comment.js
@@ -1,4 +1,5 @@
 // @ts-check
+/* eslint-disable n/no-sync, unicorn/no-process-exit */
 
 // Assemble the external-canary sticky comment markdown from per-project
 // result artifacts. Reads results/*/eslint-result.json; writes comment.md.
@@ -11,16 +12,23 @@ import path from 'node:path';
 /** @typedef {{ errors: number, warnings: number, fixable: number, files: string[] }} RuleBucket */
 
 const BIDI_ZW_CTRL = /[\u200B-\u200F\u202A-\u202E\u2060-\u2069\uFEFF]/g;
-/** @param {unknown} s */
-const stripCtrl = (s) => String(s).replace(BIDI_ZW_CTRL, '');
-/** @param {unknown} s */
+/**
+ * @param {unknown} s
+ * @returns {string}
+ */
+const stripCtrl = (s) => String(s).replaceAll(BIDI_ZW_CTRL, '');
+/**
+ * @param {unknown} s
+ * @returns {string}
+ */
 const escapeHtml = (s) => stripCtrl(s)
-  .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
-  .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+  .replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;')
+  .replaceAll('"', '&quot;').replaceAll('\'', '&#39;');
 
 const FILE_CAP = 50;
 const SIZE_CAP = 60_000;
 
+// eslint-disable-next-line n/no-process-env
 const externalCount = Number(process.env['EXTERNAL_PROJECT_COUNT'] ?? 0);
 
 const dir = 'results';
@@ -29,10 +37,13 @@ const results = [];
 if (fs.existsSync(dir)) {
   for (const sub of fs.readdirSync(dir)) {
     const file = path.join(dir, sub, 'eslint-result.json');
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
     if (!fs.existsSync(file)) continue;
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
     if (fs.statSync(file).size > 5 * 1024 * 1024) continue;
     /** @type {unknown} */
     let parsed;
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
     try { parsed = JSON.parse(fs.readFileSync(file, 'utf8')); } catch { continue; }
     if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) continue;
     const p = /** @type {Record<string, unknown>} */ (parsed);
@@ -54,14 +65,14 @@ const hasSyntheticFootnote = results.some(r => {
   return Array.isArray(sk) && sk.some(k => k === '(parser error)' || k === '(no rule id)');
 });
 
-const totalErrors    = results.reduce((s, r) => s + ((Number(r['errorCount'])          | 0)), 0);
-const totalWarnings  = results.reduce((s, r) => s + ((Number(r['warningCount'])        | 0)), 0);
-const totalFixableE  = results.reduce((s, r) => s + ((Number(r['fixableErrorCount'])   | 0)), 0);
-const totalFixableW  = results.reduce((s, r) => s + ((Number(r['fixableWarningCount']) | 0)), 0);
+const totalErrors = results.reduce((s, r) => s + Math.trunc(Number(r['errorCount'])), 0);
+const totalWarnings = results.reduce((s, r) => s + Math.trunc(Number(r['warningCount'])), 0);
+const totalFixableE = results.reduce((s, r) => s + Math.trunc(Number(r['fixableErrorCount'])), 0);
+const totalFixableW = results.reduce((s, r) => s + Math.trunc(Number(r['fixableWarningCount'])), 0);
 
 let md = '## External project test results\n\n';
 md += '**' + results.length + ' project(s) reported issues**';
-if (totalErrors > 0)   md += ' &mdash; ' + totalErrors + ' errors (' + totalFixableE + ' fixable)';
+if (totalErrors > 0) md += ' &mdash; ' + totalErrors + ' errors (' + totalFixableE + ' fixable)';
 if (totalWarnings > 0) md += ', ' + totalWarnings + ' warnings (' + totalFixableW + ' fixable)';
 md += '\n\n';
 
@@ -77,9 +88,9 @@ for (const r of results) {
     ? '<a href="https://github.com/' + slug + '"><code>' + escapeHtml(slug) + '</code></a>'
     : escapeHtml(slug);
 
-  const errorCount   = Number(r['errorCount'])   | 0;
-  const warningCount = Number(r['warningCount']) | 0;
-  const fixable      = (Number(r['fixableErrorCount']) | 0) + (Number(r['fixableWarningCount']) | 0);
+  const errorCount = Math.trunc(Number(r['errorCount']));
+  const warningCount = Math.trunc(Number(r['warningCount']));
+  const fixable = Math.trunc(Number(r['fixableErrorCount'])) + Math.trunc(Number(r['fixableWarningCount']));
   const fixStr = fixable > 0 ? ' (' + fixable + ' fixable :wrench:)' : '';
 
   md += '<details>\n<summary>' + label + ' &mdash; ' + errorCount + ' errors, ' + warningCount + ' warnings' + fixStr + '</summary>\n\n';

--- a/tools/generate-canary-comment.js
+++ b/tools/generate-canary-comment.js
@@ -60,10 +60,18 @@ if (results.length === 0) {
   process.exit(0);
 }
 
-const hasSyntheticFootnote = results.some(r => {
-  const sk = r['syntheticKeys'];
-  return Array.isArray(sk) && sk.some(k => k === '(parser error)' || k === '(no rule id)');
-});
+const SYNTHETIC_FOOTNOTE_KEYS = new Set([
+  '(parser error)',
+  '(no rule id)',
+  '(unused disable)',
+  '(missing rule)',
+]);
+
+const presentSyntheticKeys = new Set(
+  results.flatMap(r => Array.isArray(r['syntheticKeys']) ? r['syntheticKeys'] : [])
+    .filter(k => SYNTHETIC_FOOTNOTE_KEYS.has(String(k)))
+);
+const hasSyntheticFootnote = presentSyntheticKeys.size > 0;
 
 const totalErrors = results.reduce((s, r) => s + Math.trunc(Number(r['errorCount'])), 0);
 const totalWarnings = results.reduce((s, r) => s + Math.trunc(Number(r['warningCount'])), 0);
@@ -77,8 +85,15 @@ if (totalWarnings > 0) md += ', ' + totalWarnings + ' warnings (' + totalFixable
 md += '\n\n';
 
 if (hasSyntheticFootnote) {
-  md += '<sub><em><code>(parser error)</code> — ESLint reported a fatal parse/syntax error without a rule id.<br>';
-  md += '<code>(no rule id)</code> — ESLint reported a non-fatal issue without attributing it to a named rule.</em></sub>\n\n';
+  /** @type {Record<string, string>} */
+  const FOOTNOTE_TEXT = {
+    '(parser error)':  'ESLint reported a fatal parse/syntax error without a rule id.',
+    '(no rule id)':    'ESLint reported a non-fatal issue without attributing it to a named rule.',
+    '(unused disable)': 'An <code>eslint-disable</code> directive reported no matching problems — the named rule is shown next to each file.',
+    '(missing rule)':  'An <code>eslint-disable</code> / config references a rule ESLint could not load (plugin uninstalled or rule removed) — the name is shown next to each file.',
+  };
+  const lines = [...presentSyntheticKeys].sort().map(k => '<code>' + escapeHtml(k) + '</code> — ' + FOOTNOTE_TEXT[String(k)]);
+  md += '<sub><em>' + lines.join('<br>') + '</em></sub>\n\n';
 }
 
 for (const r of results) {
@@ -110,12 +125,15 @@ for (const r of results) {
     const overflow = (rule.files || []).length - shownFiles.length;
 
     const fileSpans = shownFiles.map(f => {
-      const m = /^(.+):(\d+)$/.exec(f);
+      const [pathAndLine, detail] = f.split('\t', 2);
+      const m = /^(.+):(\d+)$/.exec(pathAndLine ?? '');
+      const detailSuffix = detail ? ' <sub>' + escapeHtml(detail) + '</sub>' : '';
       if (m && isValidSlug) {
         const [, filePath, line] = m;
-        return '<a href="https://github.com/' + slug + '/blob/HEAD/' + encodeURI(filePath ?? '') + '#L' + line + '"><code>' + escapeHtml(f) + '</code></a>';
+        const encodedPath = (filePath ?? '').split('/').map(seg => encodeURIComponent(seg)).join('/');
+        return '<a href="https://github.com/' + slug + '/blob/HEAD/' + encodedPath + '#L' + line + '"><code>' + escapeHtml(pathAndLine ?? '') + '</code></a>' + detailSuffix;
       }
-      return '<code>' + escapeHtml(f) + '</code>';
+      return '<code>' + escapeHtml(pathAndLine ?? '') + '</code>' + detailSuffix;
     });
 
     const fileBlock = fileSpans.join('<br>') + (overflow > 0 ? '<br><em>... and ' + overflow + ' more</em>' : '');
@@ -126,6 +144,11 @@ for (const r of results) {
 }
 
 if (Buffer.byteLength(md, 'utf8') > SIZE_CAP) {
-  md = md.slice(0, SIZE_CAP - 5000) + '\n\n_(comment truncated — too many failures to render)_\n';
+  // Truncate at the last `</details>\n\n` boundary before the cap so we
+  // never leave an unclosed <details> tag mid-render.
+  const slice = md.slice(0, SIZE_CAP - 5000);
+  const lastClose = slice.lastIndexOf('</details>\n\n');
+  const safeEnd = lastClose !== -1 ? lastClose + '</details>\n\n'.length : slice.length;
+  md = slice.slice(0, safeEnd) + '\n\n_(comment truncated — too many failures to render)_\n';
 }
 fs.writeFileSync('comment.md', md);

--- a/tools/prepare-eslint-result.js
+++ b/tools/prepare-eslint-result.js
@@ -1,0 +1,74 @@
+// @ts-check
+
+// Aggregate one project's ESLint JSON output into a compact summary.
+// Reads project/eslint-results.json; writes eslint-result.json when there
+// are any errors or warnings. No-ruleId messages go to synthetic buckets
+// ((parser error) / (no rule id) / (invalid rule id)) so the per-rule
+// totals reconcile with the file-level totals.
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const projectPrefix = path.resolve('project') + '/';
+const project = process.env['PROJECT'] ?? '';
+
+/** @type {unknown} */
+let raw;
+try {
+  raw = JSON.parse(fs.readFileSync('project/eslint-results.json', 'utf8'));
+} catch {
+  process.exit(0);
+}
+if (!Array.isArray(raw)) process.exit(0);
+
+/** @typedef {{ errors: number, warnings: number, fixable: number, files: string[] }} RuleBucket */
+
+const totals = { errorCount: 0, warningCount: 0, fixableErrorCount: 0, fixableWarningCount: 0 };
+/** @type {Record<string, RuleBucket>} */
+const rules = {};
+/** @type {string[]} */
+const syntheticKeys = [];
+
+for (const file of raw) {
+  if (!file || typeof file !== 'object' || Array.isArray(file)) continue;
+  totals.errorCount          += (file.errorCount          | 0);
+  totals.warningCount        += (file.warningCount        | 0);
+  totals.fixableErrorCount   += (file.fixableErrorCount   | 0);
+  totals.fixableWarningCount += (file.fixableWarningCount | 0);
+  if (!Array.isArray(file.messages)) continue;
+
+  for (const msg of file.messages) {
+    if (!msg || typeof msg !== 'object') continue;
+
+    /** @type {string} */
+    let key;
+    if (msg.fatal === true) {
+      key = '(parser error)';
+    } else if (!msg.ruleId) {
+      key = '(no rule id)';
+    } else if (typeof msg.ruleId === 'string' && /^[@a-z0-9/_-]+$/i.test(msg.ruleId)) {
+      key = msg.ruleId;
+    } else {
+      key = '(invalid rule id)';
+    }
+
+    if (key.startsWith('(') && !syntheticKeys.includes(key)) syntheticKeys.push(key);
+
+    let bucket = rules[key];
+    if (!bucket) {
+      bucket = { errors: 0, warnings: 0, fixable: 0, files: [] };
+      rules[key] = bucket;
+    }
+    if (msg.severity === 2) bucket.errors++;
+    else bucket.warnings++;
+    if (msg.fix) bucket.fixable++;
+
+    const cleanPath = typeof file.filePath === 'string' && file.filePath.startsWith(projectPrefix)
+      ? file.filePath.slice(projectPrefix.length)
+      : '<unexpected path>';
+    bucket.files.push(cleanPath + ':' + msg.line);
+  }
+}
+
+if (totals.errorCount === 0 && totals.warningCount === 0) process.exit(0);
+fs.writeFileSync('eslint-result.json', JSON.stringify({ project, ...totals, syntheticKeys, rules }));

--- a/tools/prepare-eslint-result.js
+++ b/tools/prepare-eslint-result.js
@@ -1,4 +1,5 @@
 // @ts-check
+/* eslint-disable n/no-sync, unicorn/no-process-exit */
 
 // Aggregate one project's ESLint JSON output into a compact summary.
 // Reads project/eslint-results.json; writes eslint-result.json when there
@@ -10,6 +11,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 const projectPrefix = path.resolve('project') + '/';
+// eslint-disable-next-line n/no-process-env
 const project = process.env['PROJECT'] ?? '';
 
 /** @type {unknown} */
@@ -31,10 +33,10 @@ const syntheticKeys = [];
 
 for (const file of raw) {
   if (!file || typeof file !== 'object' || Array.isArray(file)) continue;
-  totals.errorCount          += (file.errorCount          | 0);
-  totals.warningCount        += (file.warningCount        | 0);
-  totals.fixableErrorCount   += (file.fixableErrorCount   | 0);
-  totals.fixableWarningCount += (file.fixableWarningCount | 0);
+  totals.errorCount += Math.trunc(file.errorCount);
+  totals.warningCount += Math.trunc(file.warningCount);
+  totals.fixableErrorCount += Math.trunc(file.fixableErrorCount);
+  totals.fixableWarningCount += Math.trunc(file.fixableWarningCount);
   if (!Array.isArray(file.messages)) continue;
 
   for (const msg of file.messages) {
@@ -46,7 +48,7 @@ for (const file of raw) {
       key = '(parser error)';
     } else if (!msg.ruleId) {
       key = '(no rule id)';
-    } else if (typeof msg.ruleId === 'string' && /^[@a-z0-9/_-]+$/i.test(msg.ruleId)) {
+    } else if (typeof msg.ruleId === 'string' && /^[@\w/-]+$/.test(msg.ruleId)) {
       key = msg.ruleId;
     } else {
       key = '(invalid rule id)';

--- a/tools/prepare-eslint-result.js
+++ b/tools/prepare-eslint-result.js
@@ -33,19 +33,35 @@ const syntheticKeys = [];
 
 for (const file of raw) {
   if (!file || typeof file !== 'object' || Array.isArray(file)) continue;
-  totals.errorCount += Math.trunc(file.errorCount);
-  totals.warningCount += Math.trunc(file.warningCount);
-  totals.fixableErrorCount += Math.trunc(file.fixableErrorCount);
-  totals.fixableWarningCount += Math.trunc(file.fixableWarningCount);
+  totals.errorCount += Math.trunc(Number(file.errorCount)) || 0;
+  totals.warningCount += Math.trunc(Number(file.warningCount)) || 0;
+  totals.fixableErrorCount += Math.trunc(Number(file.fixableErrorCount)) || 0;
+  totals.fixableWarningCount += Math.trunc(Number(file.fixableWarningCount)) || 0;
   if (!Array.isArray(file.messages)) continue;
 
   for (const msg of file.messages) {
     if (!msg || typeof msg !== 'object') continue;
 
+    const msgText = typeof msg.message === 'string' ? msg.message : '';
+
+    // Detect ESLint meta-messages so they don't masquerade as real rule violations.
+    // Unused eslint-disable directive (no problems were reported from 'n/…')
+    const unusedDisableMatch = /\(no problems were reported from '([^']{1,200})'\)/.exec(msgText);
+    // Definition for rule '<rule>' was not found
+    const missingRuleMatch = !unusedDisableMatch && /^Definition for rule '([^']{1,200})' was not found/.exec(msgText);
+
     /** @type {string} */
     let key;
+    /** @type {string} */
+    let detail = '';
     if (msg.fatal === true) {
       key = '(parser error)';
+    } else if (unusedDisableMatch) {
+      key = '(unused disable)';
+      detail = unusedDisableMatch[1] ?? '';
+    } else if (missingRuleMatch) {
+      key = '(missing rule)';
+      detail = missingRuleMatch[1] ?? '';
     } else if (!msg.ruleId) {
       key = '(no rule id)';
     } else if (typeof msg.ruleId === 'string' && /^[@\w/-]+$/.test(msg.ruleId)) {
@@ -68,7 +84,8 @@ for (const file of raw) {
     const cleanPath = typeof file.filePath === 'string' && file.filePath.startsWith(projectPrefix)
       ? file.filePath.slice(projectPrefix.length)
       : '<unexpected path>';
-    bucket.files.push(cleanPath + ':' + msg.line);
+    const fileEntry = cleanPath + ':' + (msg.line ?? '?') + (detail ? '\t' + detail : '');
+    bucket.files.push(fileEntry);
   }
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #455. The sticky-comment feature (from `2331ee5`) shipped with two regressions that were only noticeable once something failed on `main` itself — run [24667210158](https://github.com/voxpelli/eslint-config/actions/runs/24667210158) exposed both.

### Two regressions

1. **Individual job logs became unreadable** — `run eslint` writes JSON to a file (`--format json --output-file`), so on failure the only visible line is `Process completed with exit code 1`.
2. **`Post test summary` was skipped on non-PR events** — the summary job was gated on `github.event.pull_request.number`. `npm-test.yml` triggers on push-to-main and tag pushes too, where `pull_request.number` is empty → summary skipped → the artifact-to-comment pipeline never rendered anything.

Net effect: a failing external test on `main` produced zero human-readable output anywhere.

### Fixes

**Fix 1 — stylish output in the log on failure**

Insert a `show errors in log` step that re-runs ESLint with `--format stylish` on failure. `continue-on-error: true` so it doesn't disturb the already-failed state that `prepare result` + `upload result` depend on (GitHub's `failure()` context tracks ancestor-step failures independent of `continue-on-error`). Re-run cost is ~3–5s per failing project, paid only on failure.

**Fix 2 — always emit `$GITHUB_STEP_SUMMARY`, keep sticky comment PR-gated**

- Summary job `if` changes from `github.event.pull_request.number` to `needs.test_external.result != 'skipped'` — covers PR, push, and workflow_dispatch.
- New `write step summary` step pipes `comment.md` into `$GITHUB_STEP_SUMMARY` whenever there are failures to report. No new permissions, well under the 1MB cap (existing script already enforces 60KB).
- `post comment` and `delete stale comment` gain an explicit `github.event.pull_request.number` gate — sticky comments only apply to PRs.

### Event matrix after this PR

| Event | Failures | Step summary | Sticky comment |
|---|---|---|---|
| PR | yes | ✅ | ✅ |
| PR | no | — | ✅ (stale deleted) |
| Push to main | yes | ✅ (NEW) | — |
| Push to main | no | — | — |
| Tag push | yes | ✅ (NEW) | — |
| workflow_dispatch | yes | ✅ (NEW) | — |
