### PR TITLE
fix: restructure perfectionist/sort-imports groups into parallel clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Markers can combine when a rule has both a severity change and a separate config
 
 * :warning: [`es-x/no-exponential-operators`](https://eslint-community.github.io/eslint-plugin-es-x/rules/no-exponential-operators.html) – disallows the use of the `**` operator, as that's in most cases a mistake and one really meant to write `*`
 
-* :warning: [`perfectionist/sort-imports`](https://perfectionist.dev/rules/sort-imports.html) – natural-order sort of import statements, with custom `groups` ordering: type imports first, then value imports grouped by builtin → external → parent/sibling/index, splitting singleline from multiline within each tier; `newlinesBetween: 'ignore'` so downstream formatting isn't disturbed *(disabled by `noStyle`)*
+* :warning: [`perfectionist/sort-imports`](https://perfectionist.dev/rules/sort-imports.html) – natural-order sort of import statements, with custom `groups` ordering: four parallel clusters — type-singleline, type-multiline, value-singleline, value-multiline — each ordering builtin → external → [parent/sibling/index]; `newlinesBetween: 'ignore'` so downstream formatting isn't disturbed *(disabled by `noStyle`)*
 * :warning: [`perfectionist/sort-named-imports`](https://perfectionist.dev/rules/sort-named-imports.html) – natural-order sort of named import specifiers *(disabled by `noStyle`)*
 * :warning: [`perfectionist/sort-named-exports`](https://perfectionist.dev/rules/sort-named-exports.html) – natural-order sort of named export specifiers *(disabled by `noStyle`)*
 * :warning: [`perfectionist/sort-objects`](https://perfectionist.dev/rules/sort-objects.html) – natural-order sort of destructured object keys (replaces `eslint-plugin-sort-destructure-keys`) *(disabled by `noStyle`)*

--- a/base-configs/perfectionist.js
+++ b/base-configs/perfectionist.js
@@ -8,15 +8,22 @@ export const perfectionistRules = [
     rules: {
       'perfectionist/sort-imports': ['warn', {
         groups: [
-          'type-import',
-          'value-singleline-builtin',
-          'value-multiline-builtin',
-          'value-singleline-external',
-          'value-multiline-external',
+          'type-singleline-builtin',
+          'type-singleline-external',
           ['type-singleline-parent', 'type-singleline-sibling', 'type-singleline-index'],
+
+          'type-multiline-builtin',
+          'type-multiline-external',
           ['type-multiline-parent', 'type-multiline-sibling', 'type-multiline-index'],
+
+          'value-singleline-builtin',
+          'value-singleline-external',
           ['value-singleline-parent', 'value-singleline-sibling', 'value-singleline-index'],
+
+          'value-multiline-builtin',
+          'value-multiline-external',
           ['value-multiline-parent', 'value-multiline-sibling', 'value-multiline-index'],
+
           'unknown',
         ],
         newlinesBetween: 'ignore',


### PR DESCRIPTION
## Summary

Refactors the `perfectionist/sort-imports` `groups` config into four parallel, symmetric clusters.

### Before

The type-import group was a single flat entry, and value groups alternated builtin/external with singleline/multiline paired only at the parent/sibling/index tier:

```
type-import
value-singleline-builtin
value-multiline-builtin
value-singleline-external
value-multiline-external
[type-singleline-parent, sibling, index]
[type-multiline-parent, sibling, index]
[value-singleline-parent, sibling, index]
[value-multiline-parent, sibling, index]
unknown
```

### After

Four parallel clusters — type-singleline, type-multiline, value-singleline, value-multiline — each ordering builtin → external → [parent/sibling/index]:

```
type-singleline-builtin / external / [parent,sibling,index]
type-multiline-builtin  / external / [parent,sibling,index]
value-singleline-builtin / external / [parent,sibling,index]
value-multiline-builtin  / external / [parent,sibling,index]
unknown
```

Source-level blank lines between clusters are readability only; `newlinesBetween: 'ignore'` is unchanged, so no actual blank lines are added or required between imports.

## Expected effect on canary

`perfectionist/sort-imports` was the highest-volume warning on #454 (87 fires). The symmetric structure should produce more predictable orderings and fewer cross-project diff churn in the sweep-fix PRs.

## Test plan

- [x] `npm test` passes (tsc + eslint + knip + installed-check + type-coverage 96.82%)
- [ ] Canary (`external.yml`) — watch whether the \`sort-imports\` warning totals drop or move laterally across projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)