### PR TITLE
fix: pair singleline and multiline imports tier-by-tier in sort-imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Markers can combine when a rule has both a severity change and a separate config
 
 * :warning: [`es-x/no-exponential-operators`](https://eslint-community.github.io/eslint-plugin-es-x/rules/no-exponential-operators.html) – disallows the use of the `**` operator, as that's in most cases a mistake and one really meant to write `*`
 
-* :warning: [`perfectionist/sort-imports`](https://perfectionist.dev/rules/sort-imports.html) – natural-order sort of import statements, with custom `groups` ordering: four parallel clusters — type-singleline, type-multiline, value-singleline, value-multiline — each ordering builtin → external → [parent/sibling/index]; `newlinesBetween: 'ignore'` so downstream formatting isn't disturbed *(disabled by `noStyle`)*
+* :warning: [`perfectionist/sort-imports`](https://perfectionist.dev/rules/sort-imports.html) – natural-order sort of import statements, with custom `groups` ordering: type imports first, then value imports; within each, singleline and multiline are paired tier by tier — builtin → external → [parent/sibling/index]; `newlinesBetween: 'ignore'` so downstream formatting isn't disturbed *(disabled by `noStyle`)*
 * :warning: [`perfectionist/sort-named-imports`](https://perfectionist.dev/rules/sort-named-imports.html) – natural-order sort of named import specifiers *(disabled by `noStyle`)*
 * :warning: [`perfectionist/sort-named-exports`](https://perfectionist.dev/rules/sort-named-exports.html) – natural-order sort of named export specifiers *(disabled by `noStyle`)*
 * :warning: [`perfectionist/sort-objects`](https://perfectionist.dev/rules/sort-objects.html) – natural-order sort of destructured object keys (replaces `eslint-plugin-sort-destructure-keys`) *(disabled by `noStyle`)*

--- a/base-configs/perfectionist.js
+++ b/base-configs/perfectionist.js
@@ -9,19 +9,21 @@ export const perfectionistRules = [
       'perfectionist/sort-imports': ['warn', {
         groups: [
           'type-singleline-builtin',
-          'type-singleline-external',
-          ['type-singleline-parent', 'type-singleline-sibling', 'type-singleline-index'],
-
           'type-multiline-builtin',
+
+          'type-singleline-external',
           'type-multiline-external',
+
+          ['type-singleline-parent', 'type-singleline-sibling', 'type-singleline-index'],
           ['type-multiline-parent', 'type-multiline-sibling', 'type-multiline-index'],
 
           'value-singleline-builtin',
-          'value-singleline-external',
-          ['value-singleline-parent', 'value-singleline-sibling', 'value-singleline-index'],
-
           'value-multiline-builtin',
+
+          'value-singleline-external',
           'value-multiline-external',
+
+          ['value-singleline-parent', 'value-singleline-sibling', 'value-singleline-index'],
           ['value-multiline-parent', 'value-multiline-sibling', 'value-multiline-index'],
 
           'unknown',


### PR DESCRIPTION
## Summary

Refines the `perfectionist/sort-imports` `groups` config from v25.0.2's four-parallel-cluster structure to a tier-first ordering that keeps singleline and multiline imports adjacent within each tier.

### v25.0.2 structure (four parallel clusters)

```
type-singleline: builtin / external / [parent,sibling,index]
type-multiline:  builtin / external / [parent,sibling,index]
value-singleline: builtin / external / [parent,sibling,index]
value-multiline:  builtin / external / [parent,sibling,index]
unknown
```

### New structure (pair SL+ML within tier)

```
type cluster:
  singleline-builtin, multiline-builtin
  singleline-external, multiline-external
  [singleline-parent,sibling,index], [multiline-parent,sibling,index]

value cluster: same shape

unknown
```

### Why

With the parallel-cluster structure, a short singleline `import foo from 'foo'` and its sibling multiline `import { bar, baz, ... } from 'foo'` could end up separated by every other import in the file before the multiline group started. The tier-first ordering keeps imports from the same tier adjacent regardless of line shape, which reads more naturally and produces tidier diffs when a single import grows into a multiline form.

Source-level blank lines between tiers are readability only; `newlinesBetween: 'ignore'` is unchanged, so lintees see no required blank lines between imports.

## Test plan

- [x] `npm test` passes (tsc + eslint + knip + installed-check + type-coverage 96.82%)
- [x] README description synced with new structure
- [ ] Canary (`external.yml`) — compare `sort-imports` warning totals against the v25.0.2 baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)