### PR TITLE
fix: types should come _after_ ordinary imports

### DIFF
--- a/base-configs/perfectionist.js
+++ b/base-configs/perfectionist.js
@@ -8,15 +8,6 @@ export const perfectionistRules = [
     rules: {
       'perfectionist/sort-imports': ['warn', {
         groups: [
-          'type-singleline-builtin',
-          'type-multiline-builtin',
-
-          'type-singleline-external',
-          'type-multiline-external',
-
-          ['type-singleline-parent', 'type-singleline-sibling', 'type-singleline-index'],
-          ['type-multiline-parent', 'type-multiline-sibling', 'type-multiline-index'],
-
           'value-singleline-builtin',
           'value-multiline-builtin',
 
@@ -25,6 +16,15 @@ export const perfectionistRules = [
 
           ['value-singleline-parent', 'value-singleline-sibling', 'value-singleline-index'],
           ['value-multiline-parent', 'value-multiline-sibling', 'value-multiline-index'],
+
+          'type-singleline-builtin',
+          'type-multiline-builtin',
+
+          'type-singleline-external',
+          'type-multiline-external',
+
+          ['type-singleline-parent', 'type-singleline-sibling', 'type-singleline-index'],
+          ['type-multiline-parent', 'type-multiline-sibling', 'type-multiline-index'],
 
           'unknown',
         ],


### PR DESCRIPTION
This pull request reorganizes the order of type import groups in the `perfectionist/sort-imports` rule configuration within `base-configs/perfectionist.js`. The main change is to move the type-related import groups to appear after the value-related parent/sibling/index groups, aligning the import sorting order with the intended structure.

**Import sorting configuration changes:**

* Reordered the type import groups (`type-singleline-builtin`, `type-multiline-builtin`, `type-singleline-external`, `type-multiline-external`, and type-related parent/sibling/index groups) to appear after the value-related parent/sibling/index groups in the `groups` array for the `perfectionist/sort-imports` rule. [[1]](diffhunk://#diff-2aa562277843f933bb0ee5072513352c0e5350998cd78af9c0f57704d841cdf4L11-L19) [[2]](diffhunk://#diff-2aa562277843f933bb0ee5072513352c0e5350998cd78af9c0f57704d841cdf4R20-R28)